### PR TITLE
Add `bing-ru` engine + make Bing market configurable (Russian-language results)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -177,6 +177,7 @@ window.__ModuleLoader__.load({
       { id: "ddg", label: "DuckDuckGo · HTML", badge: "FREE", link: "https://duckduckgo.com" },
       { id: "ddg-lite", label: "DuckDuckGo · Lite", badge: "FREE", link: "https://duckduckgo.com" },
       { id: "bing", label: "Bing", badge: "FREE", link: "https://www.bing.com" },
+      { id: "bing-ru", label: "Bing · Русский (ru-RU)", badge: "FREE", link: "https://www.bing.com" },
       { id: "anysearch", label: "AnySearch · AI", badge: "FREE", link: "https://anysearch.com" },
       { id: "searxng", label: "SearXNG · 元搜索", badge: "FREE", link: "https://github.com/searxng/searxng" },
       { id: "exa", label: "Exa", badge: "FREE", link: "https://dashboard.exa.ai/api-keys" },

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ const ACCEPT_LANG = "zh-CN,zh;q=0.9,en;q=0.8";
 const FREE_SEARCH_NS = "free-search";
 const BRIDGE_PREFIX = "/api/dsh-free-search-settings";
 const FREE_ENGINES = ["ddg", "ddg-lite", "bing", "searxng", "anysearch"];
-const ALL_ENGINES = ["ddg", "ddg-lite", "bing", "searxng", "anysearch", "exa", "tavily", "keenable", "perplexity", "deepseek-official"];
+const ALL_ENGINES = ["ddg", "ddg-lite", "bing", "bing-ru", "searxng", "anysearch", "exa", "tavily", "keenable", "perplexity", "deepseek-official"];
 
 // 当前插件版本（发布时与 package.json 同步）
 const PLUGIN_VERSION = "0.4.22";
@@ -192,7 +192,7 @@ function uniqueSources(sources, limit) {
   return out;
 }
 
-async function fetchHtml(url, signal) {
+async function fetchHtml(url, signal, acceptLang) {
   // 单次请求超时 12s，避免挂起被当成 Connection error
   let response;
   try {
@@ -201,7 +201,7 @@ async function fetchHtml(url, signal) {
     const onAbort = () => controller.abort();
     signal?.addEventListener("abort", onAbort);
     response = await fetch(url, {
-      headers: { "user-agent": USER_AGENT, "accept-language": ACCEPT_LANG },
+      headers: { "user-agent": USER_AGENT, "accept-language": acceptLang ?? ACCEPT_LANG },
       signal: controller.signal,
       redirect: "follow",
     });
@@ -223,11 +223,11 @@ async function fetchHtml(url, signal) {
 }
 
 // 带重试的抓取：网络错误/空结果时重试，间隔 1.5s，最多 3 次
-async function fetchHtmlWithRetry(url, signal) {
+async function fetchHtmlWithRetry(url, signal, acceptLang) {
   let lastError;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
-      const html = await fetchHtml(url, signal);
+      const html = await fetchHtml(url, signal, acceptLang);
       if (html.length > 500) return html;
       lastError = new Error(`empty response (${html.length} bytes)`);
     } catch (error) {
@@ -305,7 +305,7 @@ async function searchBing(query, maxResults, options, signal) {
   if (adlt === "off") params.set("adlt", "off");
   else if (adlt === "moderate") params.set("adlt", "moderate");
   else if (adlt === "strict") params.set("adlt", "strict");
-  const html = await fetchHtmlWithRetry(`${BING_URL}?${params}`, signal);
+  const html = await fetchHtmlWithRetry(`${BING_URL}?${params}`, signal, options?.acceptLang);
   const blocks = html.match(/<li class="b_algo"[\s\S]*?<\/li>/g) ?? [];
   const sources = [];
   for (const block of blocks) {
@@ -320,6 +320,15 @@ async function searchBing(query, maxResults, options, signal) {
     });
   }
   return { sources: uniqueSources(sources, maxResults ?? 10), truncated: false };
+}
+
+// 俄语 Bing：强制 ru-RU 市场 + 俄语 accept-language（复用 Bing 解析逻辑）
+async function searchBingRu(query, maxResults, options, signal) {
+  return searchBing(query, maxResults, {
+    ...options,
+    bingMarket: "ru-RU",
+    acceptLang: "ru-RU,ru;q=0.9,en;q=0.8",
+  }, signal);
 }
 
 //#region searxng (meta-search, free instances, auto-failover)
@@ -1419,7 +1428,7 @@ const KEY_REF_MAP = {
 };
 
 const Config = z.object({
-  provider: z.string().default("bing"),
+  provider: z.string().default("bing-ru"),
   cache: z.boolean().default(true), // 单 query 结果缓存开关（防限流/省额度）
   cacheTtl: z.number().default(5), // 缓存时长（分钟），0-5 可配置（使用处再 clamp）
   keyStorage: z.string().default("credentials"), // key 存储位置：credentials（凭据中心）| settings（设置页）
@@ -1507,7 +1516,7 @@ function apply(ctx, config) {
 
       // 统一引擎链：首选优先，然后其他付费引擎（有 key 的优先尝试），最后免费引擎
       const paidEngines = ["exa", "tavily", "keenable", "perplexity", "deepseek-official"];
-      const freeEngines = ["bing", "anysearch", "ddg", "ddg-lite", "searxng"];
+      const freeEngines = ["bing", "bing-ru", "anysearch", "ddg", "ddg-lite", "searxng"];
       // 支持 time_range 过滤的引擎：tavily / exa / keenable / searxng / ddg / ddg-lite
       const timeEngines = ["tavily", "exa", "keenable", "searxng", "ddg", "ddg-lite"];
       let chain;
@@ -1554,6 +1563,8 @@ function apply(ctx, config) {
             result = await searchDdgLite(request.query, request.maxResults, { ...cfg, timeRange }, effSignal);
           } else if (engine === "bing") {
             result = await searchBing(request.query, request.maxResults, cfg, effSignal);
+          } else if (engine === "bing-ru") {
+            result = await searchBingRu(request.query, request.maxResults, cfg, effSignal);
           } else if (engine === "searxng") {
             result = await searchSearxng(request.query, request.maxResults, { ...cfg, timeRange }, effSignal);
           } else if (engine === "anysearch") {
@@ -1692,6 +1703,8 @@ function apply(ctx, config) {
           return await searchDdgLite(q, 2, { ...cfg, timeRange: tr });
         case "bing":
           return await searchBing(q, 2, cfg);
+        case "bing-ru":
+          return await searchBingRu(q, 2, cfg);
         case "searxng":
           return await searchSearxng(q, 2, { ...cfg, timeRange: tr });
         case "anysearch":
@@ -1754,7 +1767,7 @@ function apply(ctx, config) {
           parameters: {
             engines: {
               type: "array",
-              description: "Which engines to test (default: all). Options: ddg, ddg-lite, bing, searxng, anysearch, exa, tavily, keenable, perplexity, deepseek-official.",
+              description: "Which engines to test (default: all). Options: ddg, ddg-lite, bing, bing-ru, searxng, anysearch, exa, tavily, keenable, perplexity, deepseek-official.",
               items: { type: "string" },
             },
             query: {
@@ -1938,7 +1951,7 @@ function apply(ctx, config) {
             },
             engine: {
               type: "string",
-              description: "Optional specific engine to try first: ddg, ddg-lite, bing, searxng, anysearch, exa, tavily, keenable, perplexity, deepseek-official.",
+              description: "Optional specific engine to try first: ddg, ddg-lite, bing, bing-ru, searxng, anysearch, exa, tavily, keenable, perplexity, deepseek-official.",
             },
           },
           output: {
@@ -2029,6 +2042,7 @@ function apply(ctx, config) {
           "- ddg (DuckDuckGo HTML) - FREE, no key (may be rate-limited)",
           "- ddg-lite (DuckDuckGo Lite) - FREE, no key (may be rate-limited)",
           "- bing (Bing) - FREE, no key (most stable)",
+          "- bing-ru (Bing · Russian ru-RU market) - FREE, no key (Russian-language results)",
           "- searxng (meta-search, multi-instance) - FREE, no key",
           "- anysearch (AI search) - FREE, no key",
           "- exa - FREE keyless (MCP) or EXA_API_KEY for higher limits",
@@ -2083,6 +2097,7 @@ export {
   parseTimeRange,
   searchAnysearch,
   searchBing,
+  searchBingRu,
   searchBilibili,
   searchDeepSeekOfficial,
   searchDdgHtml,


### PR DESCRIPTION
See issue #18.

This adds a `bing-ru` engine that forces Bing `mkt=ru-RU` and a Russian `accept-language`, reusing the existing Bing parser. The original `bing` (zh-CN) stays as a fallback. Also wires the engine into the engine list, test tool, UI, and system prompt.

Alternative (cleaner for upstream): reuse the existing `Config.lang` field to pick the Bing `mkt` instead of a separate engine id.